### PR TITLE
Adding server host to the example in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@
       app.use(express.session({ 
         secret: 'CatOnTheKeyboard', 
         store: new MemcachedStore({
-          hosts: [ '127.0.0.1:11212' ] // set to your memcache server's host; see Options for additional info
+          hosts: [ '127.0.0.1:11212' ] // Change this to your memcache server(s). See Options for additional info.
         })
       }));
 


### PR DESCRIPTION
I think this is the cause of this guy's trouble: http://stackoverflow.com/questions/15523243/node-js-no-response-returned-while-using-connect-memcached/15670471
