### PR TITLE
Add language hints to code blocks.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,62 +7,66 @@
 
   via npm:
 
-      $ npm install connect-memcached
+```bash
+$ npm install connect-memcached
+```
 
 ## Example
 
-      /**
-      * Module dependencies.
-      */
+```js
+/**
+* Module dependencies.
+*/
 
-      var express = require('express');
+var express = require('express');
 
-      // pass the express to the connect memcached module
-      // allowing it to inherit from express.session.Store
-      var MemcachedStore = require('connect-memcached')(express);
+// pass the express to the connect memcached module
+// allowing it to inherit from express.session.Store
+var MemcachedStore = require('connect-memcached')(express);
 
-      var app = express.createServer();
+var app = express.createServer();
 
-      app.use(express.favicon());
+app.use(express.favicon());
 
-      // request logging
-      app.use(express.logger());
+// request logging
+app.use(express.logger());
 
-      // required to parse the session cookie
-      app.use(express.cookieParser());
+// required to parse the session cookie
+app.use(express.cookieParser());
 
-      // Populates:
-      // - req.session
-      // - req.sessionStore
-      // - req.sessionID (or req.session.id)
+// Populates:
+// - req.session
+// - req.sessionStore
+// - req.sessionID (or req.session.id)
 
-      app.use(express.session({ 
-        secret: 'CatOnTheKeyboard', 
-        store: new MemcachedStore 
-      }));
+app.use(express.session({
+  secret: 'CatOnTheKeyboard',
+  store: new MemcachedStore
+}));
 
-      app.get('/', function(req, res){
-        if (req.session.views) {
-          ++req.session.views;
-        } else {
-          req.session.views = 1;
-        }
-        res.send('Viewed <strong>' + req.session.views + '</strong> times.');
-      });
+app.get('/', function(req, res){
+  if (req.session.views) {
+    ++req.session.views;
+  } else {
+    req.session.views = 1;
+  }
+  res.send('Viewed <strong>' + req.session.views + '</strong> times.');
+});
 
-      app.listen(3000);
-      console.log('Express app started on port 3000');
+app.listen(3000);
+console.log('Express app started on port 3000');
+```
 
 ## Options
 
     - `hosts` Memcached servers locations, can by string, array, hash.
-    - `prefix` An optional prefix for each memcache key, in case you are sharing 
-               your memcached servers with something generating its own keys. 
+    - `prefix` An optional prefix for each memcache key, in case you are sharing
+               your memcached servers with something generating its own keys.
     - ...     Rest of given option will be passed directly to the node-memcached constructor.
 
   For details see [node-memcached](http://github.com/3rd-Eden/node-memcached).
 
-## License 
+## License
 
 (The MIT License)
 


### PR DESCRIPTION
This pull request changes the code blocks to use fences instead of indentation and adds language hints so github color codes the blocks appropriately. I think this improves the readability of the example code drastically: https://github.com/brianloveswords/connect-memcached/tree/fix-readme
