### PR TITLE
Transparent encryption support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,8 @@
       app.use(express.session({
         secret: 'CatOnTheKeyboard',
         store: new MemcachedStore({
-          hosts: [ '127.0.0.1:11211' ] // Change this to your memcache server(s). See Options for additional info.
+          hosts: [ '127.0.0.1:11211' ], // Change this to your memcache server(s). See Options for additional info.
+          secret: '123, easy as ABC. ABC, easy as 123' // Optionally use transparent encryption for memcache session data
         })
       }));
 
@@ -59,6 +60,8 @@
 - `hosts` Memcached servers locations, can by string, array, hash.
 - `prefix` An optional prefix for each memcache key, in case you are sharing
            your memcached servers with something generating its own keys.
+- `secret` An optional secret can be used to encrypt/decrypt session contents.
+- `algorithm` An optional algorithm parameter may be used, but must be valid based on returned `crypto.getCiphers()`. The current default is `aes-256-ctr` and was chosen based on the following [information](http://www.daemonology.net/blog/2009-06-11-cryptographic-right-answers.html)
 - ...     Rest of given option will be passed directly to the node-memcached constructor.
 
 For details see [node-memcached](http://github.com/3rd-Eden/node-memcached).

--- a/lib/connect-memcached.js
+++ b/lib/connect-memcached.js
@@ -36,6 +36,13 @@ module.exports = function(connect) {
 			if (!options.hosts) {
 				options.hosts = '127.0.0.1:11211';
 			}
+      if (options.secret) {
+        this.crypto = require('crypto'),
+        this.secret = options.secret;
+      }
+      if (options.algorithm) {
+        this.algorithm = options.algorithm;
+      }
 
 			options.client = new Memcached(options.hosts, options);
 		}
@@ -70,7 +77,7 @@ module.exports = function(connect) {
 	 * @api public
 	 */
 	MemcachedStore.prototype.get = function(sid, fn) {
-		sid = this.getKey(sid);
+    secret = this.secret, self = this,	sid = this.getKey(sid);
 
 		this.client.get(sid, function(err, data) {
       if (err) { return fn(err, {}); }
@@ -78,7 +85,8 @@ module.exports = function(connect) {
 				if (!data) {
 					return fn();
 				}
-				fn(null, JSON.parse(data.toString()));
+				fn(null, JSON.parse((secret) ? decryptData.call(self, data.toString()) :
+                            data.toString()));
 			} catch (e) {
 				fn(e);
 			}
@@ -99,7 +107,10 @@ module.exports = function(connect) {
 		try {
 			var maxAge = sess.cookie.maxAge;
 			var ttl = 'number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay;
-			var sess = JSON.stringify(sess);
+			var sess = JSON.stringify((this.secret) ?
+                                encryptData.call(this, JSON.stringify(sess),
+                                                 this.secret, this.algorithm) :
+                                sess);
 
 			this.client.set(sid, sess, ttl, ensureCallback(fn));
 		} catch (err) {
@@ -138,6 +149,56 @@ module.exports = function(connect) {
 	MemcachedStore.prototype.clear = function(fn) {
 		this.client.flush(ensureCallback(fn));
 	};
+
+  function encryptData(plaintext){
+    var pt = encrypt.call(this, this.secret, plaintext, this.algo)
+      , hmac = digest.call(this, this.secret, pt);
+
+    return {
+      ct: pt,
+      mac: hmac
+    };
+  }
+
+  function decryptData(ciphertext){
+    ciphertext = JSON.parse(ciphertext)
+    var hmac = digest.call(this, this.secret, ciphertext.ct);
+
+    if (hmac != ciphertext.mac) {
+      throw 'Encrypted session was tampered with!';
+    }
+
+    return decrypt.call(this, this.secret, ciphertext.ct, this.algo);
+  }
+
+  function digest(key, obj) {
+    var hmac = this.crypto.createHmac('sha512', key);
+    hmac.setEncoding('hex');
+    hmac.write(obj);
+    hmac.end();
+    return hmac.read();
+  }
+
+  function encrypt(key, pt, algo) {
+    algo = algo || 'aes-256-ctr';
+    pt = (Buffer.isBuffer(pt)) ? pt : new Buffer(pt);
+
+    var cipher = this.crypto.createCipher(algo, key), ct = [];
+    ct.push(cipher.update(pt, 'buffer', 'hex'));
+    ct.push(cipher.final('hex'));
+
+    return ct.join('');
+  }
+
+  function decrypt(key, ct, algo) {
+    algo = algo || 'aes-256-ctr';
+    var cipher = this.crypto.createDecipher(algo, key), pt = [];
+
+    pt.push(cipher.update(ct, 'hex', 'utf8'));
+    pt.push(cipher.final('utf8'));
+
+    return pt.join('');
+  }
 
 	return MemcachedStore;
 };


### PR DESCRIPTION
This PR will provide optional encryption support for all session data set and retrieved from the memcached service. Please see the [OWASP Session Management (session content)](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Session_ID_Content_.28or_Value.29) documentation for reasoning behind adding this support.

lib/connect-memcached.js:
 Configuration:
  - Optionally specify a 'secret' and 'algorithm' (valid list retrieved from
    crypto.getCiphers())
 Public:
  - MemcachedStore.prototype.set: Encrypts data based on 'secret' option
  - MemcachedStore.prototype.get: Decrypts data based on 'secret' option
 Private:
  - encryptData(plaintext): Wrapper for encrypting data using specified key & algorithm
                            while also creating a MAC based on results of encryption.
  - decryptData(ciphertext): Wrapper for decrypting data. First performs validation of
                             cipher text based on stored MAC value, then decrypts payload.
  - digest(key, ct): Creates an SHA512 MAC of cipher text & is used to verify stored
                     cipher text for tampering.
  - encrypt(key, pt, algo): Generates cipher text value based on supplied secret & algorithm.
  - decrypt(key, ct, algo): Decrypts cipher text to plain text using supplied secret & algorithm.

Readme.md:
 Updated example & list of configuration options to reflect this pull request's
 functionality.