### PR TITLE
Made compatible to Express 4.x

### DIFF
--- a/lib/connect-memcached.js
+++ b/lib/connect-memcached.js
@@ -19,7 +19,7 @@ function ensureCallback(fn) {
  * @api public
  */
 module.exports = function(session) {
-	var Store = session.Store;
+	var Store = connect.Store || connect.session.Store;
 
 	/**
 	 * Initialize MemcachedStore with the given `options`.


### PR DESCRIPTION
In Express 4.x, express.session does not exist any more, but is put into npm module express-session.
So now if you want to use it use mongoStore(expressSession)
