### PR TITLE
Adding functionality to support a default TTL without having a maxAge…

### DIFF
--- a/lib/connect-memcached.js
+++ b/lib/connect-memcached.js
@@ -32,6 +32,7 @@ module.exports = function(session) {
 		Store.call(this, options);
 
 		this.prefix = options.prefix || '';
+		this.ttl = options.ttl;
 		if (!options.client) {
 			if (!options.hosts) {
 				options.hosts = '127.0.0.1:11211';
@@ -91,7 +92,7 @@ module.exports = function(session) {
 
 		try {
 			var maxAge = sess.cookie.maxAge;
-			var ttl = 'number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay;
+			var ttl = this.ttl || ('number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay);
 			var sess = JSON.stringify(sess);
 
 			this.client.set(sid, sess, ttl, ensureCallback(fn));


### PR DESCRIPTION
Adding functionality to support a default TTL without having a maxAge on the cookie. This is necessary if you want to have a browser session cookie (which means that the maxAge/expires will be false or null) but you may still want the server side to have session expiration after a set period of time. This is currently supported by connect-redis and should also be supported for connect-memcached.