### PR TITLE
fix: non-overwriting touch semantic support. See issue #27

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,6 +50,7 @@ http.createServer(app).listen(9341, function() {
 - `ttl` An optional parameter used for setting the default TTL
 - `secret` An optional secret can be used to encrypt/decrypt session contents.
 - `algorithm` An optional algorithm parameter may be used, but must be valid based on returned `crypto.getCiphers()`. The current default is `aes-256-ctr` and was chosen based on the following [information](http://www.daemonology.net/blog/2009-06-11-cryptographic-right-answers.html)
+- `serverSupportsTouch` Set true if your memcached server version is at least 1.4.14 to enable the more efficient touch protocol.
 - ...     Rest of given option will be passed directly to the node-memcached constructor.
 
 For details see [node-memcached](http://github.com/3rd-Eden/node-memcached).

--- a/lib/connect-memcached.js
+++ b/lib/connect-memcached.js
@@ -31,6 +31,7 @@ module.exports = function(session) {
         options = options || {};
         Store.call(this, options);
 
+        this.serverSupportsTouch = options.serverSupportsTouch;
         this.prefix = options.prefix || '';
         this.ttl = options.ttl;
         if (!options.client) {
@@ -107,8 +108,7 @@ module.exports = function(session) {
         sid = this.getKey(sid);
 
         try {
-            var maxAge = sess.cookie.maxAge;
-            var ttl = this.ttl || ('number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay);
+            var ttl = computeTtl.call(this, sess);
             var sess = JSON.stringify((this.secret) ?
                                 encryptData.call(this, JSON.stringify(sess),
                                                  this.secret, this.algorithm) :
@@ -161,10 +161,36 @@ module.exports = function(session) {
 	 * @api public
  	 */
 
-	MemcachedStore.prototype.touch = function (sid, sess, fn) {
-		this.set(sid, sess, fn);
-	}
+    MemcachedStore.prototype.touch = function (sid, sess, fn) {
+        sid = this.getKey(sid);
 
+        try {
+            var ttl = computeTtl.call(this, sess);
+            var self = this;
+
+            // memcached.touch support introduced in 1.4.8 and buggy until 1.4.14
+            // when touch not supported implement it using get+set as modelled in MemoryStore
+            // Memcached.version is not robust so we use options flag to disable work-around
+
+            if (this.serverSupportsTouch) {
+                this.client.touch(sid, ttl, ensureCallback(fn));
+            } else {
+                self.client.get(sid, function(err, data) {
+                    if (err) {
+                        return fn && fn(err);
+                    }
+                    self.client.set(sid, data, ttl, ensureCallback(fn));
+                });
+            }
+        } catch (err) {
+            fn && fn(err);
+        }
+    }
+
+    function computeTtl(sess) {
+        var maxAge = sess.cookie.maxAge;
+        return this.ttl || ('number' == typeof maxAge ? maxAge / 1000 | 0 : oneDay);
+    }
 
     function encryptData(plaintext){
         var pt = encrypt.call(this, this.secret, plaintext, this.algo)


### PR DESCRIPTION
Background: 
- the express session store touch semantic is used to update the session expiration and assumes the session body will not be changed. This semantic is necessary to support requests handlers that reference but do not modify the session that execute in parallel with a request handler that does modify the session.
- memcached server natively supports the expected touch semantic in version 1.4.14 (actually 1.4.8 but it is buggy). Anecdotally, memcached native touch is not widely deployed, so it cannot be counted on. 

Change description: 
- the existing incorrect implementation of using "set" as an alias for "touch" is enhanced to use "get then set" which reduces the surface area of the race condition from the entire request cycle down to the few milliseconds needed for memcached access.
- a new optional flag `serverSupportsTouch` is provided to enable native memcached touch support.

Impact of change: 
- existing consumers not needing the corrected semantic are not impacted.
- consumers needing corrected semantic who do not opt-in to the native touch support become less likely to experience data overwrite loss after this change as the race condition window is reduced.
- consumers who opt-in to the native touch support will get the optimal behavior.

See also issue #27.