### PR TITLE
Crypto: Replaces all crypto with kruptein module

### DIFF
--- a/lib/connect-memcached.js
+++ b/lib/connect-memcached.js
@@ -39,14 +39,15 @@ module.exports = function(session) {
       if (!options.hosts) {
         options.hosts = "127.0.0.1:11211";
       }
-      if (options.secret) {
-        (this.crypto = require("crypto")), (this.secret = options.secret);
-      }
-      if (options.algorithm) {
-        this.algorithm = options.algorithm;
-      }
 
       options.client = new Memcached(options.hosts, options);
+    }
+
+    if (options.secret) {
+      options.algorithm = options.algorithm || 'aes-256-gcm';
+      options.hashing = options.hashing || 'sha512';
+      this.kruptein = require("kruptein")(options);
+      this.secret = options.secret;
     }
 
     this.client = options.client;
@@ -72,7 +73,8 @@ module.exports = function(session) {
    * @api public
    */
   MemcachedStore.prototype.get = function(sid, fn) {
-    (secret = this.secret), (self = this), (sid = this.getKey(sid));
+    var secret = this.secret, self = this, sid = this.getKey(sid),
+        parseable_string;
 
     this.client.get(sid, function(err, data) {
       if (err) {
@@ -82,8 +84,14 @@ module.exports = function(session) {
         if (!data) {
           return fn();
         }
+
         if (secret) {
-          parseable_string = decryptData.call(self, data.toString());
+          self.kruptein.get(secret, data, function(err, ct) {
+            if (err)
+              return fn(err, {});
+
+            parseable_string = JSON.parse(ct);
+          });
         } else {
           parseable_string = data.toString();
         }
@@ -110,16 +118,15 @@ module.exports = function(session) {
       var maxAge = sess.cookie.maxAge;
       var ttl =
         this.ttl || ("number" == typeof maxAge ? (maxAge / 1000) | 0 : oneDay);
-      var sess = JSON.stringify(
-        this.secret
-          ? encryptData.call(
-              this,
-              JSON.stringify(sess),
-              this.secret,
-              this.algorithm
-            )
-          : sess
-      );
+
+      if (this.client.secret) {
+        this.kruptein.set(this.client.secret, JSON.stringify(sess), function(err, ct) {
+          if (err)
+            return fn(err);
+          
+          sess = ct;
+        });
+      }
 
       this.client.set(sid, sess, ttl, ensureCallback(fn));
     } catch (err) {
@@ -171,71 +178,6 @@ module.exports = function(session) {
   MemcachedStore.prototype.touch = function(sid, sess, fn) {
     this.set(sid, sess, fn);
   };
-
-  function encryptData(plaintext) {
-    var pt = encrypt.call(this, this.secret, plaintext, this.algo),
-      hmac = digest.call(this, this.secret, pt);
-
-    return {
-      ct: pt,
-      mac: hmac
-    };
-  }
-
-  function decryptData(ciphertext) {
-    ciphertext = JSON.parse(ciphertext);
-
-    var hmac = digest.call(this, this.secret, ciphertext.ct);
-
-    if (hmac != ciphertext.mac) {
-      throw "Encrypted session was tampered with!";
-    }
-
-    return decrypt.call(this, this.secret, ciphertext.ct, this.algo);
-  }
-
-  function digest(key, obj) {
-    var hmac = this.crypto.createHmac("sha512", key);
-    hmac.setEncoding("hex");
-    hmac.write(obj);
-    hmac.end();
-    return hmac.read();
-  }
-
-  function encrypt(key, pt, algo) {
-    algo = algo || "aes-256-ctr";
-    pt = Buffer.isBuffer(pt) ? pt : new bufferFrom(pt);
-    var iv = this.crypto.randomBytes(16);
-    var hashedKey = this.crypto
-      .createHash("sha256")
-      .update(key)
-      .digest();
-    var cipher = this.crypto.createCipheriv(algo, hashedKey, iv),
-      ct = [];
-    ct.push(iv.toString("hex"));
-    ct.push(cipher.update(pt, "buffer", "hex"));
-    ct.push(cipher.final("hex"));
-
-    return ct.join("");
-  }
-
-  function decrypt(key, ct, algo) {
-    algo = algo || "aes-256-ctr";
-    var dataBuffer = bufferFrom(ct, "hex");
-    var iv = dataBuffer.slice(0, 16);
-    var hashedKey = this.crypto
-      .createHash("sha256")
-      .update(key)
-      .digest();
-
-    var cipher = this.crypto.createDecipheriv(algo, hashedKey, iv),
-      pt = [];
-
-    pt.push(cipher.update(dataBuffer.slice(16), "hex", "utf8"));
-    pt.push(cipher.final("utf8"));
-
-    return pt.join("");
-  }
 
   return MemcachedStore;
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "buffer-from": "1.1.0",
+    "kruptein": "^2.0.4",
     "memcached": "2.2.x"
   },
   "engines": {


### PR DESCRIPTION
Greetings and salutations,

This PR will replace all of the one off crypto calls with the [kruptein](https://www.npmjs.com/package/kruptein) module. This change will provide greater flexibility for clients to select ciphers, modes, key derivation & hashing options which ensuring the result will conform to best practices regarding symmetric cryptography.

